### PR TITLE
Get alias of the actual required action when updating action throught the admin API

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -1006,7 +1006,7 @@ public class AuthenticationManagementResource {
         RequiredActionProviderModel update = new RequiredActionProviderModel();
         update.setId(model.getId());
         update.setName(rep.getName());
-        update.setAlias(rep.getAlias());
+        update.setAlias(model.getAlias());
         update.setProviderId(model.getProviderId());
         update.setDefaultAction(rep.isDefaultAction());
         update.setPriority(rep.getPriority());


### PR DESCRIPTION
Hello,

When performing the following request `PUT /{realm}/authentication/required-actions/{alias}`, the API supposed the data sent contain the alias of the action but there is no verification done.

Here is an example below after doing the request `PUT /{realm}/authentication/required-actions/VERIFY_EMAIL` with data `{"enabeled" : false}`. Alias has disappeared and the action (VERIFY_EMAIL) is completely unusable. 


```json
[
  {
    "providerId": "VERIFY_EMAIL",
    "enabled": false,
    "defaultAction": false,
    "priority": 0,
    "config": {}
  },
  {
    "alias": "CONFIGURE_TOTP",
    "name": "Configure OTP",
    "providerId": "CONFIGURE_TOTP",
    "enabled": true,
    "defaultAction": false,
    "priority": 0,
    "config": {}
  },
  {
    "alias": "terms_and_conditions",
    "name": "Terms and Conditions",
    "providerId": "terms_and_conditions",
    "enabled": false,
    "defaultAction": false,
    "priority": 0,
    "config": {}
  }
...
]

```

In the admin interface
![image](https://user-images.githubusercontent.com/11663791/131865218-37554274-ade8-4922-8d12-aa6a12ac8203.png)


I suggest to get the alias from the `model` object that is reflecting the current configuration if I understood correctly.